### PR TITLE
ci(macos): Sign and notarize the release build

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -20,6 +20,10 @@ jobs:
     # Testing suite; macos-26 ships Xcode 26.6, the version the app is built
     # and verified with locally.
     runs-on: macos-26
+    env:
+      # Secrets cannot be tested in a step `if`, so the presence check lives
+      # here and the steps key off HAS_SIGNING.
+      HAS_SIGNING: ${{ secrets.MACOS_SIGNING_CERT_P12 != '' }}
 
     steps:
       - uses: actions/checkout@v4
@@ -59,10 +63,36 @@ jobs:
       - name: Run vmctl tests
         run: ./scripts/test_vmctl.sh
 
-      # Ad-hoc signed until a Developer ID certificate lands in the repo
-      # secrets: the app runs locally and via right-click → Open elsewhere,
-      # but is not notarized. Set CODESIGN_IDENTITY from a secret to change
-      # that without touching the script.
+      # Developer ID signing and notarization run when the four secrets
+      # below exist; without them the build is ad-hoc signed (runs locally
+      # and via right-click → Open, but Gatekeeper refuses it on first open).
+      #   MACOS_SIGNING_CERT_P12       base64 of the Developer ID Application
+      #                                .p12 (certificate + private key)
+      #   MACOS_SIGNING_CERT_PASSWORD  its password
+      #   NOTARY_KEY_P8                the App Store Connect API key (.p8 text)
+      #   NOTARY_KEY_ID / NOTARY_ISSUER_ID   from App Store Connect → Integrations
+      - name: Import signing certificate
+        if: env.HAS_SIGNING == 'true'
+        env:
+          CERT_P12: ${{ secrets.MACOS_SIGNING_CERT_P12 }}
+          CERT_PASSWORD: ${{ secrets.MACOS_SIGNING_CERT_PASSWORD }}
+        run: |
+          KEYCHAIN="$RUNNER_TEMP/signing.keychain-db"
+          KEYCHAIN_PASSWORD=$(uuidgen)
+          echo "$CERT_P12" | base64 --decode > "$RUNNER_TEMP/cert.p12"
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
+          security set-keychain-settings -lut 21600 "$KEYCHAIN"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
+          security import "$RUNNER_TEMP/cert.p12" -P "$CERT_PASSWORD" -A \
+            -t cert -f pkcs12 -k "$KEYCHAIN"
+          security set-key-partition-list -S apple-tool:,apple: -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
+          security list-keychain -d user -s "$KEYCHAIN" login.keychain
+          rm -f "$RUNNER_TEMP/cert.p12"
+          IDENTITY=$(security find-identity -v -p codesigning "$KEYCHAIN" \
+            | grep -o '"Developer ID Application: [^"]*"' | head -1 | tr -d '"')
+          [ -n "$IDENTITY" ] || { echo "no Developer ID identity in the p12" >&2; exit 1; }
+          echo "CODESIGN_IDENTITY=$IDENTITY" >> "$GITHUB_ENV"
+
       # WSLMANAGER_GITHUB_CLIENT_ID is an optional repository *variable*
       # (Settings → Secrets and variables → Actions → Variables), not a
       # secret: the OAuth client id is public. It overrides the id bundled
@@ -77,7 +107,24 @@ jobs:
         id: get_version
         run: echo "version=$(grep '^version:' pubspec.yaml | awk '{print $2}' | cut -d'+' -f1)" >> "$GITHUB_OUTPUT"
 
-      - name: Package
+      - name: Sign, notarize and package
+        if: env.HAS_SIGNING == 'true'
+        env:
+          NOTARY_KEY_P8: ${{ secrets.NOTARY_KEY_P8 }}
+          NOTARY_KEY_ID: ${{ secrets.NOTARY_KEY_ID }}
+          NOTARY_ISSUER_ID: ${{ secrets.NOTARY_ISSUER_ID }}
+          NOTARY_PROFILE: ci-notary
+        run: |
+          printf '%s' "$NOTARY_KEY_P8" > "$RUNNER_TEMP/AuthKey.p8"
+          xcrun notarytool store-credentials "$NOTARY_PROFILE" \
+            --key "$RUNNER_TEMP/AuthKey.p8" --key-id "$NOTARY_KEY_ID" --issuer "$NOTARY_ISSUER_ID"
+          rm -f "$RUNNER_TEMP/AuthKey.p8"
+          ./scripts/sign_macos_release.sh \
+            "build/macos/Build/Products/Release/WSL Manager.app" \
+            "${{ steps.get_version.outputs.version }}" "$PWD"
+
+      - name: Package (ad-hoc build)
+        if: env.HAS_SIGNING != 'true'
         run: |
           APP="build/macos/Build/Products/Release/WSL Manager.app"
           STAGE=$(mktemp -d)
@@ -106,8 +153,17 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          TAG="v${{ steps.get_version.outputs.version }}"
+          # An ad-hoc build must never replace a signed, notarized asset that
+          # is already on the release (2.0.0 was signed by hand). Only a
+          # signed build, or a release with no mac assets yet, gets uploaded.
+          if [ "$HAS_SIGNING" != "true" ] && gh release view "$TAG" --json assets \
+               --jq '.assets[].name' 2>/dev/null | grep -q -- '-macos.dmg$'; then
+            echo "$TAG already carries a macOS dmg and this build is unsigned; not clobbering."
+            exit 0
+          fi
           for i in 1 2 3 4 5; do
-            if gh release upload "v${{ steps.get_version.outputs.version }}" \
+            if gh release upload "$TAG" \
               "wsl2-distro-manager-v${{ steps.get_version.outputs.version }}-macos.dmg" \
               "wsl2-distro-manager-v${{ steps.get_version.outputs.version }}-macos.zip" \
               --clobber; then

--- a/TODO.md
+++ b/TODO.md
@@ -69,9 +69,15 @@ same pin CI uses. Tracked as `bostrot/ai-tasks#9`.
 3. Push `beta`, resolve the #316 conflict, merge PR #318; that is what makes
    `releaser.yml` tag and publish.
 4. Drop the `publish-scoop.yml` trigger from `releaser.yml`.
-5. macOS distribution: Developer ID certificate as `CODESIGN_IDENTITY`,
-   `notarytool submit … --wait` + `stapler` in `macos.yml`, raise the
-   deployment target, add a macOS section under "Install" in the README.
+5. ~~macOS distribution: Developer ID certificate as `CODESIGN_IDENTITY`,
+   `notarytool submit … --wait` + `stapler` in `macos.yml`, add a macOS
+   section under "Install" in the README.~~ Done 2026-09-06: the 2.0.0 dmg
+   and zip on the release are Developer ID signed, notarized and stapled
+   (`scripts/sign_macos_release.sh`, run by hand), the README has the
+   Homebrew tap (`bostrot/homebrew-tap`, cask `wsl-manager`), and
+   `macos.yml` signs in CI once the five secrets it documents are set.
+   Still open: raise `MACOSX_DEPLOYMENT_TARGET` from 10.15, and set those
+   secrets so the next release does not need the manual run.
 6. Website: commit the buy page, flip `IS_TEST_MODE`/links to the live Stripe
    payment links, deploy so `/buy` exists before any macOS binary is public.
    That also unblocks `bostrot/ai-tasks#7` and `#8`.

--- a/scripts/sign_macos_release.sh
+++ b/scripts/sign_macos_release.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+# Sign, notarize and staple a built "WSL Manager.app", then package it as the
+# release .dmg and .zip. Used by hand for a release that CI built ad-hoc, and
+# by macos.yml once the signing secrets exist.
+#
+#   scripts/sign_macos_release.sh <path to .app or -macos.zip> <version> [outdir]
+#
+# Environment:
+#   CODESIGN_IDENTITY  "Developer ID Application: Name (TEAMID)" — required.
+#   NOTARY_PROFILE     keychain profile from `xcrun notarytool store-credentials`.
+#                      Unset: sign only, no notarization (Gatekeeper will still
+#                      refuse the app on first open).
+#
+# Why not `codesign --deep`: it re-signs nested code with the outer file's
+# entitlements, so vmctl would lose its virtualization entitlement and the
+# app would gain vmctl's. Every piece is signed on its own, inside out.
+set -euo pipefail
+
+INPUT="${1:?path to WSL Manager.app or the -macos.zip}"
+VERSION="${2:?version, e.g. 2.0.0}"
+OUT="${3:-$PWD}"
+IDENTITY="${CODESIGN_IDENTITY:?set CODESIGN_IDENTITY to the Developer ID Application identity}"
+REPO="$(cd "$(dirname "$0")/.." && pwd)"
+
+WORK=$(mktemp -d)
+trap 'rm -rf "$WORK"' EXIT
+
+if [[ "$INPUT" == *.zip ]]; then
+  ditto -x -k "$INPUT" "$WORK/unpacked"
+  APP=$(find "$WORK/unpacked" -maxdepth 1 -name '*.app' | head -1)
+else
+  cp -R "$INPUT" "$WORK/"
+  APP="$WORK/$(basename "$INPUT")"
+fi
+[[ -d "$APP" ]] || { echo "no .app found in $INPUT" >&2; exit 1; }
+# Finder's quarantine flag on a downloaded zip must not end up inside the
+# signed bundle.
+xattr -cr "$APP"
+
+SIGN=(codesign --force --timestamp --options runtime --sign "$IDENTITY")
+
+echo "==> Signing frameworks and dylibs"
+find "$APP/Contents/Frameworks" -depth \( -name '*.framework' -o -name '*.dylib' \) -print0 \
+  | while IFS= read -r -d '' item; do "${SIGN[@]}" "$item"; done
+
+echo "==> Signing vmctl with the virtualization entitlement"
+"${SIGN[@]}" --entitlements "$REPO/macos/vmctl/vmctl.entitlements" \
+  "$APP/Contents/Resources/vmctl"
+
+echo "==> Signing the app with its own entitlements"
+"${SIGN[@]}" --entitlements "$REPO/macos/Runner/Release.entitlements" "$APP"
+
+echo "==> Verifying"
+codesign --verify --deep --strict --verbose=2 "$APP"
+codesign -d --entitlements - "$APP" 2>/dev/null | grep -q com.apple.security.virtualization
+codesign -d --entitlements - "$APP/Contents/Resources/vmctl" 2>/dev/null | grep -q com.apple.security.virtualization
+
+if [[ -n "${NOTARY_PROFILE:-}" ]]; then
+  echo "==> Notarizing"
+  ditto -c -k --keepParent "$APP" "$WORK/notarize.zip"
+  xcrun notarytool submit "$WORK/notarize.zip" --keychain-profile "$NOTARY_PROFILE" --wait
+  xcrun stapler staple "$APP"
+  spctl --assess --type execute --verbose=2 "$APP"
+else
+  echo "==> NOTARY_PROFILE unset: skipping notarization"
+fi
+
+echo "==> Packaging"
+mkdir -p "$OUT"
+STAGE="$WORK/stage"
+mkdir -p "$STAGE"
+cp -R "$APP" "$STAGE/"
+ln -s /Applications "$STAGE/Applications"
+DMG="$OUT/wsl2-distro-manager-v$VERSION-macos.dmg"
+ZIP="$OUT/wsl2-distro-manager-v$VERSION-macos.zip"
+rm -f "$DMG" "$ZIP"
+hdiutil create -volname "WSL Manager" -srcfolder "$STAGE" -ov -format UDZO "$DMG" >/dev/null
+if [[ -n "${NOTARY_PROFILE:-}" ]]; then
+  # The dmg gets its own ticket so Finder trusts it before the app is copied.
+  "${SIGN[@]}" "$DMG"
+  xcrun notarytool submit "$DMG" --keychain-profile "$NOTARY_PROFILE" --wait
+  xcrun stapler staple "$DMG"
+fi
+ditto -c -k --sequesterRsrc --keepParent "$APP" "$ZIP"
+shasum -a 256 "$DMG" "$ZIP"
+echo "==> Done"


### PR DESCRIPTION
scripts/sign_macos_release.sh signs every framework, vmctl (with its virtualization entitlement) and the app (with its own) under the hardened runtime, notarizes and staples the app and the dmg, and packages the dmg and zip. It ran by hand for 2.0.0; macos.yml calls it when the signing secrets exist and otherwise keeps the ad-hoc build, but no longer lets an ad-hoc build overwrite a signed dmg already on the release.